### PR TITLE
Fix case-insensitive field mapping

### DIFF
--- a/src/Bearpro.AutoCrapper/AutoCrapper.cs
+++ b/src/Bearpro.AutoCrapper/AutoCrapper.cs
@@ -164,7 +164,8 @@ namespace Bearpro.AutoCrapper
             if (map.SourcePath.Count == 0)
             {
                 var last = map.DestinationPath.Last();
-                var sp = (MemberInfo?)typeof(TSrc).GetProperty(last.Name) ?? typeof(TSrc).GetField(last.Name);
+                var sp = (MemberInfo?)typeof(TSrc).GetProperty(last.Name, BindingFlags.Instance | BindingFlags.Public | BindingFlags.IgnoreCase)
+                    ?? typeof(TSrc).GetField(last.Name, BindingFlags.Instance | BindingFlags.Public | BindingFlags.IgnoreCase);
                 if (sp != null) map.SourcePath.Add(sp);
             }
             _config.PropertyMaps.Add(map);
@@ -301,7 +302,8 @@ namespace Bearpro.AutoCrapper
                     continue;
                 if (map.IgnoreUnmapped)
                     continue;
-                MemberInfo? sp = map.SrcType.GetProperty(prop.Name) as MemberInfo ?? map.SrcType.GetField(prop.Name);
+                MemberInfo? sp = (MemberInfo?)map.SrcType.GetProperty(prop.Name, BindingFlags.Instance | BindingFlags.Public | BindingFlags.IgnoreCase)
+                    ?? map.SrcType.GetField(prop.Name, BindingFlags.Instance | BindingFlags.Public | BindingFlags.IgnoreCase);
                 if (sp == null)
                     continue;
 


### PR DESCRIPTION
## Summary
- allow field/property matching without case sensitivity

## Testing
- `dotnet test src/auto-crapper.sln -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_68707dcc7ba483258eb0be7791669ca1